### PR TITLE
Fix account type card overflow on mobile by switching to 2x2 grid

### DIFF
--- a/templates/spending_tracker/add_account.html
+++ b/templates/spending_tracker/add_account.html
@@ -21,6 +21,12 @@
             margin-bottom: 20px;
         }
 
+        @media (min-width: 480px) {
+            .mode-selector {
+                grid-template-columns: repeat(4, 1fr);
+            }
+        }
+
         .mode-option {
             padding: 15px;
             border: 2px solid #dee2e6;

--- a/templates/spending_tracker/add_account.html
+++ b/templates/spending_tracker/add_account.html
@@ -15,13 +15,13 @@
         }
 
         .mode-selector {
-            display: flex;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
             gap: 10px;
             margin-bottom: 20px;
         }
 
         .mode-option {
-            flex: 1;
             padding: 15px;
             border: 2px solid #dee2e6;
             border-radius: 8px;


### PR DESCRIPTION
The 4 account type cards were in a single flex row which caused the
last card (Cash) to overflow/clip on narrow mobile screens. Replacing
the flex row with a CSS grid (2 columns) ensures all options are always
fully visible without any scrolling.

https://claude.ai/code/session_0154tkspBvWcG6xz3txT94fF

## Summary by Sourcery

Bug Fixes:
- Fix mobile layout where the last account type card overflowed by switching the selector to a responsive two-column grid.