### PR TITLE
Hide top navbar on mobile in spending tracker reports

### DIFF
--- a/templates/spending_tracker/reports.html
+++ b/templates/spending_tracker/reports.html
@@ -203,6 +203,12 @@
                 opacity: 0.8;
             }
         }
+
+        @media (max-width: 768px) {
+            .navbar {
+                display: none !important;
+            }
+        }
     </style>
 
 </head>


### PR DESCRIPTION
The reports template is standalone (does not extend base.html), so the
mobile-hiding CSS from base.html was not applied. Added the same
@media (max-width: 768px) rule to hide .navbar on mobile screens.

https://claude.ai/code/session_01ViezzdaQe81Ff1rVjRP7zL

## Summary by Sourcery

Enhancements:
- Add a mobile-specific media query in the reports template to hide the navbar on screens narrower than 768px.