### PR TITLE
Redesign mobile bottom nav: active states, a11y, logout relocation

### DIFF
--- a/pwa/migrations/0003_notification_is_read.py
+++ b/pwa/migrations/0003_notification_is_read.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pwa', '0002_remove_endpoint_unique_constraint'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='notification',
+            name='is_read',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/pwa/models.py
+++ b/pwa/models.py
@@ -42,6 +42,7 @@ class Notification(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     sent = models.BooleanField(default=False)
     sent_at = models.DateTimeField(blank=True, null=True)
+    is_read = models.BooleanField(default=False)
 
     class Meta:
         ordering = ['-created_at']

--- a/pwa/urls.py
+++ b/pwa/urls.py
@@ -12,4 +12,8 @@ urlpatterns = [
     path('api/push/vapid-public-key/', views.vapid_public_key, name='vapid_public_key'),
     path('api/push/subscribe/', views.subscribe_push, name='subscribe_push'),
     path('api/push/unsubscribe/', views.unsubscribe_push, name='unsubscribe_push'),
+
+    # In-app notification feed
+    path('api/notifications/', views.notifications_list, name='notifications_list'),
+    path('api/notifications/read/', views.mark_notifications_read, name='mark_notifications_read'),
 ]

--- a/pwa/views.py
+++ b/pwa/views.py
@@ -8,7 +8,7 @@ from django.http import JsonResponse, HttpResponse
 from django.views.decorators.cache import cache_control
 from django.views.decorators.http import require_http_methods
 
-from .models import PushSubscription
+from .models import PushSubscription, Notification
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +77,36 @@ def subscribe_push(request):
     except Exception as e:
         logger.exception(f"subscribe_push failed for user {request.user.username}")
         return JsonResponse({'error': str(e)}, status=500)
+
+
+@login_required
+@require_http_methods(["GET"])
+def notifications_list(request):
+    """Return the 10 most recent notifications for the current user."""
+    qs = request.user.notifications.all()[:10]
+    unread_count = request.user.notifications.filter(is_read=False).count()
+    return JsonResponse({
+        'unread_count': unread_count,
+        'notifications': [
+            {
+                'id': n.id,
+                'title': n.title,
+                'body': n.body,
+                'url': n.url or '',
+                'is_read': n.is_read,
+                'created_at': n.created_at.isoformat(),
+            }
+            for n in qs
+        ],
+    })
+
+
+@login_required
+@require_http_methods(["POST"])
+def mark_notifications_read(request):
+    """Mark all of the current user's notifications as read."""
+    request.user.notifications.filter(is_read=False).update(is_read=True)
+    return JsonResponse({'success': True})
 
 
 @login_required

--- a/seoto/static/js/install-prompt.js
+++ b/seoto/static/js/install-prompt.js
@@ -29,9 +29,6 @@
   function showInstallButton() {
     if (!shouldShowPrompt()) return;
 
-    const bottomBtn = document.getElementById('install-button-bottom');
-    if (bottomBtn) bottomBtn.style.visibility = 'visible';
-
     ['install-button', 'install-button-profile'].forEach(function(id) {
       const btn = document.getElementById(id);
       if (btn) btn.style.display = 'flex';
@@ -40,9 +37,6 @@
 
   // Hide the install button
   function hideInstallButton() {
-    const bottomBtn = document.getElementById('install-button-bottom');
-    if (bottomBtn) bottomBtn.style.visibility = 'hidden';
-
     ['install-button', 'install-button-profile'].forEach(function(id) {
       const btn = document.getElementById(id);
       if (btn) btn.style.display = 'none';
@@ -114,7 +108,7 @@
 
   // Attach click handler when DOM is ready
   window.addEventListener('DOMContentLoaded', () => {
-    ['install-button', 'install-button-bottom', 'install-button-profile'].forEach(function(id) {
+    ['install-button', 'install-button-profile'].forEach(function(id) {
       const btn = document.getElementById(id);
       if (btn) {
         btn.addEventListener('click', handleInstallClick);

--- a/seoto/static/js/install-prompt.js
+++ b/seoto/static/js/install-prompt.js
@@ -27,18 +27,23 @@
 
   // Show the install button
   function showInstallButton() {
-    ['install-button', 'install-button-bottom', 'install-button-profile'].forEach(function(id) {
+    if (!shouldShowPrompt()) return;
+
+    const bottomBtn = document.getElementById('install-button-bottom');
+    if (bottomBtn) bottomBtn.style.visibility = 'visible';
+
+    ['install-button', 'install-button-profile'].forEach(function(id) {
       const btn = document.getElementById(id);
-      if (btn && shouldShowPrompt()) {
-        btn.style.display = 'flex';
-      }
+      if (btn) btn.style.display = 'flex';
     });
-    console.log('Install button shown - PWA can be installed');
   }
 
   // Hide the install button
   function hideInstallButton() {
-    ['install-button', 'install-button-bottom', 'install-button-profile'].forEach(function(id) {
+    const bottomBtn = document.getElementById('install-button-bottom');
+    if (bottomBtn) bottomBtn.style.visibility = 'hidden';
+
+    ['install-button', 'install-button-profile'].forEach(function(id) {
       const btn = document.getElementById(id);
       if (btn) btn.style.display = 'none';
     });

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -365,6 +365,25 @@
                                     </div>
                                 </div>
 
+                                <!-- Sign out -->
+                                <div class="settings-item">
+                                    <div class="settings-icon" style="background:#fdecea; color:#c0392b;">
+                                        <i class="fas fa-sign-out-alt"></i>
+                                    </div>
+                                    <div class="settings-body">
+                                        <div class="settings-title">Sign Out</div>
+                                        <div class="settings-desc">Log out of your account</div>
+                                    </div>
+                                    <div class="settings-action">
+                                        <form method="POST" action="{% url 'logout' %}">
+                                            {% csrf_token %}
+                                            <button type="submit" class="btn btn-outline-danger" style="font-size:0.8rem; padding:5px 14px; border-radius:20px;">
+                                                Sign out
+                                            </button>
+                                        </form>
+                                    </div>
+                                </div>
+
                             </div>
                         </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -214,11 +214,6 @@
             border-radius: 6px;
         }
 
-        /* Install slot stays in the layout but invisible until JS shows it */
-        .bottom-nav-item.install-slot {
-            /* visibility toggled by install-prompt.js via style attribute */
-        }
-
         /* Back button — regular flex item, sits naturally after the others */
         .bottom-nav-back {
             flex: 0 0 72px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -454,6 +454,133 @@
                 padding-top: env(safe-area-inset-top);
             }
         }
+
+        /* ── Custom button system ──────────────────────────────────────────── */
+        /* Shape, typography, interactions — colors come from the theme processor */
+
+        .btn {
+            border-radius: 8px;
+            font-weight: 500;
+            font-size: 0.875rem;
+            letter-spacing: 0.015em;
+            padding: 8px 18px;
+            line-height: 1.3;
+            border-width: 1.5px;
+            border-style: solid;
+            transition: filter 0.15s ease, box-shadow 0.15s ease,
+                        background-color 0.15s ease, color 0.15s ease,
+                        transform 0.1s ease;
+            -webkit-tap-highlight-color: transparent;
+        }
+
+        .btn-sm {
+            border-radius: 6px;
+            font-size: 0.8rem;
+            padding: 5px 12px;
+        }
+
+        .btn-lg {
+            border-radius: 10px;
+            font-size: 1rem;
+            padding: 10px 24px;
+        }
+
+        /* Replace Bootstrap's box-shadow focus ring with a clean outline */
+        .btn:focus {
+            box-shadow: none;
+        }
+        .btn:focus-visible {
+            outline: 2px solid currentColor;
+            outline-offset: 2px;
+            box-shadow: none;
+        }
+
+        /* Tactile press feedback */
+        .btn:active {
+            transform: scale(0.97);
+        }
+
+        /* Soft colored glow on hover — matches the app's subtle shadow language */
+        .btn-primary:hover   { box-shadow: 0 3px 12px rgba( 23,  90, 156, 0.30); }
+        .btn-success:hover   { box-shadow: 0 3px 12px rgba( 40, 167,  69, 0.30); }
+        .btn-danger:hover    { box-shadow: 0 3px 12px rgba(220,  53,  69, 0.30); }
+        .btn-warning:hover   { box-shadow: 0 3px 12px rgba(255, 193,   7, 0.25); }
+        .btn-info:hover      { box-shadow: 0 3px 12px rgba( 23, 162, 184, 0.30); }
+        .btn-secondary:hover { box-shadow: 0 3px 12px rgba(108, 117, 125, 0.25); }
+
+        /* Outline variants — border and text use theme variables; fill on hover */
+        .btn-outline-primary {
+            border-color: var(--theme-primary, #175a9c);
+            color:        var(--theme-primary, #175a9c);
+            background:   transparent;
+        }
+        .btn-outline-primary:hover,
+        .btn-outline-primary:focus {
+            background-color: var(--theme-primary, #175a9c);
+            border-color:     var(--theme-primary, #175a9c);
+            color:            #fff;
+            box-shadow:       0 3px 12px rgba(23, 90, 156, 0.25);
+        }
+
+        .btn-outline-secondary {
+            border-color: var(--theme-secondary, #6c757d);
+            color:        var(--theme-secondary, #6c757d);
+            background:   transparent;
+        }
+        .btn-outline-secondary:hover,
+        .btn-outline-secondary:focus {
+            background-color: var(--theme-secondary, #6c757d);
+            border-color:     var(--theme-secondary, #6c757d);
+            color: #fff;
+        }
+
+        .btn-outline-success {
+            border-color: var(--theme-btn-success-bg, #28a745);
+            color:        var(--theme-btn-success-bg, #28a745);
+            background:   transparent;
+        }
+        .btn-outline-success:hover,
+        .btn-outline-success:focus {
+            background-color: var(--theme-btn-success-bg, #28a745);
+            border-color:     var(--theme-btn-success-bg, #28a745);
+            color:            var(--theme-btn-success-text, #fff);
+        }
+
+        .btn-outline-danger {
+            border-color: var(--theme-btn-danger-bg, #dc3545);
+            color:        var(--theme-btn-danger-bg, #dc3545);
+            background:   transparent;
+        }
+        .btn-outline-danger:hover,
+        .btn-outline-danger:focus {
+            background-color: var(--theme-btn-danger-bg, #dc3545);
+            border-color:     var(--theme-btn-danger-bg, #dc3545);
+            color:            var(--theme-btn-danger-text, #fff);
+        }
+
+        .btn-outline-warning {
+            border-color: var(--theme-btn-warning-bg, #ffc107);
+            color:        var(--theme-btn-warning-bg, #ffc107);
+            background:   transparent;
+        }
+        .btn-outline-warning:hover,
+        .btn-outline-warning:focus {
+            background-color: var(--theme-btn-warning-bg, #ffc107);
+            border-color:     var(--theme-btn-warning-bg, #ffc107);
+            color:            var(--theme-btn-warning-text, #000);
+        }
+
+        .btn-outline-info {
+            border-color: var(--theme-btn-info-bg, #17a2b8);
+            color:        var(--theme-btn-info-bg, #17a2b8);
+            background:   transparent;
+        }
+        .btn-outline-info:hover,
+        .btn-outline-info:focus {
+            background-color: var(--theme-btn-info-bg, #17a2b8);
+            border-color:     var(--theme-btn-info-bg, #17a2b8);
+            color:            var(--theme-btn-info-text, #fff);
+        }
     </style>
     {% block style %}{% endblock %}
 </head>

--- a/templates/base.html
+++ b/templates/base.html
@@ -148,14 +148,16 @@
             background: #fff;
             box-shadow: 0 -1px 0 rgba(0, 0, 0, .06), 0 -4px 20px rgba(0, 0, 0, .07);
             display: none; /* hidden by default; shown on mobile below */
-            padding: 0 4px;
+            justify-content: center;
+            gap: 4px;
+            padding: 0 16px;
             padding-bottom: env(safe-area-inset-bottom);
             min-height: calc(56px + env(safe-area-inset-bottom));
             z-index: 1030;
         }
 
         .bottom-nav-item {
-            flex: 1;
+            flex: 0 0 72px;
             display: flex;
             flex-direction: column;
             align-items: center;

--- a/templates/base.html
+++ b/templates/base.html
@@ -145,65 +145,90 @@
             bottom: 0;
             left: 0;
             right: 0;
-            background-color: #f8f9fa;
-            border-top: 1px solid #dee2e6;
-            display: flex;
-            align-items: center;
-            justify-content: space-around;
-            z-index: 1030;
+            background: #fff;
+            box-shadow: 0 -1px 0 rgba(0, 0, 0, .06), 0 -4px 20px rgba(0, 0, 0, .07);
+            display: none; /* hidden by default; shown on mobile below */
             padding: 0 4px;
-            /* Reserve space for iOS home indicator — items sit above it */
             padding-bottom: env(safe-area-inset-bottom);
-            min-height: calc(60px + env(safe-area-inset-bottom));
+            min-height: calc(56px + env(safe-area-inset-bottom));
+            z-index: 1030;
         }
 
         .bottom-nav-item {
+            flex: 1;
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            gap: 2px;
-            font-size: 0.65rem;
-            color: #495057;
+            gap: 3px;
+            padding: 8px 4px 6px;
+            color: #9ca3af;
+            font-size: 0.7rem;
+            font-weight: 500;
+            letter-spacing: 0.01em;
             text-decoration: none;
             background: none;
             border: none;
-            padding: 6px 10px;
-            border-radius: 8px;
             cursor: pointer;
-            min-width: 44px;
+            position: relative;
             min-height: 44px;
-            transition: color 0.15s ease, background-color 0.15s ease;
-            flex: 1;
-            max-width: 80px;
+            min-width: 44px;
+            transition: color 0.15s ease;
+            -webkit-tap-highlight-color: transparent;
         }
 
         .bottom-nav-item i {
-            font-size: 1.1rem;
+            font-size: 1.2rem;
             line-height: 1;
+            transition: transform 0.15s ease;
         }
 
-        .bottom-nav-item:hover,
-        .bottom-nav-item:focus {
+        /* Active page indicator — thin bar at top of item */
+        .bottom-nav-item.active {
             color: #175a9c;
-            background-color: rgba(23, 90, 156, 0.08);
-            outline: none;
         }
 
-        /* Hide top navbar on mobile; bottom nav takes over */
+        .bottom-nav-item.active::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 28px;
+            height: 3px;
+            background: #175a9c;
+            border-radius: 0 0 4px 4px;
+        }
+
+        /* Subtle press feedback */
+        .bottom-nav-item:active i {
+            transform: scale(0.88);
+        }
+
+        /* Keyboard focus ring — use :focus-visible so mouse clicks are unaffected */
+        .bottom-nav-item:focus-visible {
+            outline: 2px solid #175a9c;
+            outline-offset: -3px;
+            border-radius: 6px;
+        }
+
+        /* Install slot stays in the layout but invisible until JS shows it */
+        .bottom-nav-item.install-slot {
+            /* visibility toggled by install-prompt.js via style attribute */
+        }
+
+        /* Mobile: show bottom nav, hide top navbar, pad page content */
         @media (max-width: 768px) {
+            .bottom-nav {
+                display: flex;
+            }
+
             .navbar {
                 display: none !important;
             }
-            .page-container {
-                padding-bottom: calc(68px + env(safe-area-inset-bottom));
-            }
-        }
 
-        /* Bottom nav hidden on desktop (Bootstrap d-md-none handles this too) */
-        @media (min-width: 769px) {
-            .bottom-nav {
-                display: none !important;
+            .page-container {
+                padding-bottom: calc(64px + env(safe-area-inset-bottom));
             }
         }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -267,6 +267,177 @@
             animation: nav-tap-flash 0.35s ease-out forwards;
         }
 
+        /* Divider between main items and Back */
+        .nav-divider {
+            width: 1px;
+            height: 20px;
+            background: #e5e7eb;
+            align-self: center;
+            flex-shrink: 0;
+            margin: 0 2px;
+        }
+
+        /* Notification bell wrapper (holds icon + badge) */
+        .notif-bell-wrap {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .notif-badge {
+            position: absolute;
+            top: -5px;
+            right: -7px;
+            min-width: 16px;
+            height: 16px;
+            padding: 0 3px;
+            background: #e53e3e;
+            color: #fff;
+            font-size: 0.6rem;
+            font-weight: 700;
+            border-radius: 99px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            line-height: 1;
+            border: 1.5px solid #fff;
+        }
+
+        /* Notification overlay (behind panel, above page content) */
+        .notif-overlay {
+            display: none;
+            position: fixed;
+            inset: 0;
+            z-index: 1028;
+            background: rgba(0, 0, 0, 0.25);
+        }
+
+        .notif-overlay.active {
+            display: block;
+        }
+
+        /* Notification bottom-sheet panel */
+        .notif-panel {
+            position: fixed;
+            left: 0;
+            right: 0;
+            bottom: calc(56px + env(safe-area-inset-bottom));
+            max-height: 60vh;
+            background: #fff;
+            border-radius: 16px 16px 0 0;
+            box-shadow: 0 -4px 24px rgba(0, 0, 0, .12);
+            z-index: 1029;
+            display: flex;
+            flex-direction: column;
+            transform: translateY(110%);
+            transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        .notif-panel.open {
+            transform: translateY(0);
+        }
+
+        .notif-panel-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 14px 16px 10px;
+            border-bottom: 1px solid #f3f4f6;
+            flex-shrink: 0;
+        }
+
+        .notif-panel-title {
+            font-size: 0.95rem;
+            font-weight: 700;
+            color: #111827;
+        }
+
+        .notif-panel-close {
+            background: none;
+            border: none;
+            color: #9ca3af;
+            font-size: 1rem;
+            cursor: pointer;
+            padding: 4px;
+            line-height: 1;
+            border-radius: 4px;
+            -webkit-tap-highlight-color: transparent;
+        }
+
+        .notif-panel-close:focus-visible {
+            outline: 2px solid #175a9c;
+        }
+
+        .notif-list {
+            overflow-y: auto;
+            flex: 1;
+            overscroll-behavior: contain;
+        }
+
+        .notif-item {
+            padding: 14px 16px;
+            border-bottom: 1px solid #f3f4f6;
+            cursor: default;
+            border-left: 3px solid transparent;
+            transition: background 0.15s;
+        }
+
+        .notif-item[data-url] {
+            cursor: pointer;
+        }
+
+        .notif-item[data-url]:active {
+            background: #f9fafb;
+        }
+
+        .notif-item.unread {
+            background: #f0f5ff;
+            border-left-color: #175a9c;
+        }
+
+        .notif-item-title {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #111827;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            margin-bottom: 2px;
+        }
+
+        .notif-item-body {
+            font-size: 0.78rem;
+            color: #6b7280;
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            margin-bottom: 4px;
+        }
+
+        .notif-item-time {
+            font-size: 0.68rem;
+            color: #9ca3af;
+        }
+
+        .notif-loading,
+        .notif-empty {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            padding: 32px 16px;
+            color: #9ca3af;
+            font-size: 0.85rem;
+        }
+
+        .notif-loading i,
+        .notif-empty i {
+            font-size: 1.6rem;
+        }
+
         /* Mobile: show bottom nav, hide top navbar, pad page content */
         @media (max-width: 768px) {
             .bottom-nav {

--- a/templates/base.html
+++ b/templates/base.html
@@ -219,14 +219,9 @@
             /* visibility toggled by install-prompt.js via style attribute */
         }
 
-        /* Back button — pinned to the right side of the nav */
+        /* Back button — regular flex item, sits naturally after the others */
         .bottom-nav-back {
-            position: absolute;
-            right: 8px;
-            top: 0;
-            bottom: env(safe-area-inset-bottom, 0px);
-            min-width: 56px;
-            min-height: 44px;
+            flex: 0 0 72px;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -236,6 +231,8 @@
             color: #9ca3af;
             font-size: 0.7rem;
             font-weight: 500;
+            min-height: 44px;
+            min-width: 44px;
             background: none;
             border: none;
             cursor: pointer;

--- a/templates/base.html
+++ b/templates/base.html
@@ -219,6 +219,57 @@
             /* visibility toggled by install-prompt.js via style attribute */
         }
 
+        /* Back button — pinned to the right side of the nav */
+        .bottom-nav-back {
+            position: absolute;
+            right: 8px;
+            top: 0;
+            bottom: env(safe-area-inset-bottom, 0px);
+            min-width: 56px;
+            min-height: 44px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 3px;
+            padding: 8px 4px 6px;
+            color: #9ca3af;
+            font-size: 0.7rem;
+            font-weight: 500;
+            background: none;
+            border: none;
+            cursor: pointer;
+            -webkit-tap-highlight-color: transparent;
+            transition: color 0.15s ease;
+        }
+
+        .bottom-nav-back i {
+            font-size: 1.2rem;
+            line-height: 1;
+            transition: transform 0.15s ease;
+        }
+
+        .bottom-nav-back:active i {
+            transform: scale(0.88);
+        }
+
+        .bottom-nav-back:focus-visible {
+            outline: 2px solid #175a9c;
+            outline-offset: -3px;
+            border-radius: 6px;
+        }
+
+        /* Tap flash — triggered by .nav-tap class added in JS on pointerdown */
+        @keyframes nav-tap-flash {
+            0%   { background: rgba(23, 90, 156, 0.14); border-radius: 8px; color: #175a9c; }
+            100% { background: transparent; color: inherit; }
+        }
+
+        .bottom-nav-item.nav-tap,
+        .bottom-nav-back.nav-tap {
+            animation: nav-tap-flash 0.35s ease-out forwards;
+        }
+
         /* Mobile: show bottom nav, hide top navbar, pad page content */
         @media (max-width: 768px) {
             .bottom-nav {

--- a/templates/partials/_bottom_nav.html
+++ b/templates/partials/_bottom_nav.html
@@ -1,13 +1,5 @@
 <nav class="bottom-nav" aria-label="Mobile navigation">
 
-    <button class="bottom-nav-back" id="bottom-nav-back"
-            onclick="history.back()"
-            aria-label="Go back"
-            title="Go back">
-        <i class="fas fa-chevron-left" aria-hidden="true"></i>
-        <span>Back</span>
-    </button>
-
     <a href="{% url 'index' %}"
        class="bottom-nav-item{% if request.resolver_match.url_name == 'index' %} active{% endif %}"
        aria-current="{% if request.resolver_match.url_name == 'index' %}page{% else %}false{% endif %}">
@@ -61,6 +53,14 @@
         </button>
 
     {% endif %}
+
+    <button class="bottom-nav-back" id="bottom-nav-back"
+            onclick="history.back()"
+            aria-label="Go back"
+            title="Go back">
+        <i class="fas fa-chevron-left" aria-hidden="true"></i>
+        <span>Back</span>
+    </button>
 
 </nav>
 

--- a/templates/partials/_bottom_nav.html
+++ b/templates/partials/_bottom_nav.html
@@ -1,3 +1,24 @@
+{% url 'pwa:notifications_list' as notif_url %}
+{% url 'pwa:mark_notifications_read' as notif_read_url %}
+
+<!-- Notification dropdown panel (slides up from above the nav) -->
+{% if user.is_authenticated %}
+<div id="notif-overlay" class="notif-overlay" aria-hidden="true"></div>
+<div id="notif-panel" class="notif-panel" role="dialog" aria-label="Notifications" aria-hidden="true">
+    <div class="notif-panel-header">
+        <span class="notif-panel-title">Notifications</span>
+        <button class="notif-panel-close" id="notif-close" aria-label="Close notifications">
+            <i class="fas fa-times" aria-hidden="true"></i>
+        </button>
+    </div>
+    <div class="notif-list" id="notif-list">
+        <div class="notif-loading">
+            <i class="fas fa-spinner fa-spin"></i>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <nav class="bottom-nav" aria-label="Mobile navigation">
 
     <a href="{% url 'index' %}"
@@ -8,6 +29,15 @@
     </a>
 
     {% if user.is_authenticated %}
+
+        <button class="bottom-nav-item" id="notif-toggle"
+                aria-label="Notifications" aria-expanded="false" aria-controls="notif-panel">
+            <span class="notif-bell-wrap">
+                <i class="fas fa-bell" aria-hidden="true"></i>
+                <span class="notif-badge" id="notif-badge" style="display:none;"></span>
+            </span>
+            <span>Alerts</span>
+        </button>
 
         <a href="{% url 'profile' user.username %}"
            class="bottom-nav-item{% if request.resolver_match.url_name == 'profile' %} active{% endif %}"
@@ -54,11 +84,13 @@
 
     {% endif %}
 
+    <div class="nav-divider" aria-hidden="true"></div>
+
     <button class="bottom-nav-back" id="bottom-nav-back"
             onclick="history.back()"
             aria-label="Go back"
             title="Go back">
-        <i class="fas fa-chevron-left" aria-hidden="true"></i>
+        <i class="fas fa-arrow-left" aria-hidden="true"></i>
         <span>Back</span>
     </button>
 
@@ -66,12 +98,134 @@
 
 <script>
 (function () {
+    var NOTIF_URL  = '{{ notif_url }}';
+    var READ_URL   = '{{ notif_read_url }}';
+
+    function getCsrf() {
+        var match = document.cookie.match(/csrftoken=([^;]+)/);
+        return match ? match[1] : '';
+    }
+
+    function timeAgo(iso) {
+        var diff = (Date.now() - new Date(iso)) / 1000;
+        if (diff < 60)     return 'just now';
+        if (diff < 3600)   return Math.floor(diff / 60) + 'm ago';
+        if (diff < 86400)  return Math.floor(diff / 3600) + 'h ago';
+        if (diff < 604800) return Math.floor(diff / 86400) + 'd ago';
+        return new Date(iso).toLocaleDateString();
+    }
+
+    function setBadge(count) {
+        var badge = document.getElementById('notif-badge');
+        if (!badge) return;
+        if (count > 0) {
+            badge.textContent = count > 9 ? '9+' : count;
+            badge.style.display = 'flex';
+        } else {
+            badge.style.display = 'none';
+        }
+    }
+
+    function renderNotifications(items) {
+        var list = document.getElementById('notif-list');
+        if (!list) return;
+        if (!items.length) {
+            list.innerHTML = '<div class="notif-empty"><i class="fas fa-bell-slash"></i><span>No notifications yet</span></div>';
+            return;
+        }
+        list.innerHTML = items.map(function (n) {
+            var cls = n.is_read ? 'notif-item' : 'notif-item unread';
+            var url = n.url ? ' data-url="' + n.url + '"' : '';
+            return '<div class="' + cls + '"' + url + '>'
+                + '<div class="notif-item-title">' + n.title + '</div>'
+                + '<div class="notif-item-body">' + n.body + '</div>'
+                + '<div class="notif-item-time">' + timeAgo(n.created_at) + '</div>'
+                + '</div>';
+        }).join('');
+
+        list.querySelectorAll('.notif-item[data-url]').forEach(function (el) {
+            el.addEventListener('click', function () {
+                window.location.href = el.dataset.url;
+            });
+        });
+    }
+
+    function openPanel() {
+        var panel   = document.getElementById('notif-panel');
+        var overlay = document.getElementById('notif-overlay');
+        var toggle  = document.getElementById('notif-toggle');
+        if (!panel) return;
+
+        panel.classList.add('open');
+        panel.setAttribute('aria-hidden', 'false');
+        overlay.classList.add('active');
+        if (toggle) toggle.setAttribute('aria-expanded', 'true');
+
+        // Fetch notifications
+        fetch(NOTIF_URL, { credentials: 'same-origin' })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                renderNotifications(data.notifications);
+                setBadge(0); // clear badge once panel is open
+
+                // Mark all as read
+                fetch(READ_URL, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'X-CSRFToken': getCsrf() },
+                })
+                .catch(function () {});
+            })
+            .catch(function () {
+                var list = document.getElementById('notif-list');
+                if (list) list.innerHTML = '<div class="notif-empty"><i class="fas fa-exclamation-circle"></i><span>Could not load notifications</span></div>';
+            });
+    }
+
+    function closePanel() {
+        var panel   = document.getElementById('notif-panel');
+        var overlay = document.getElementById('notif-overlay');
+        var toggle  = document.getElementById('notif-toggle');
+        if (!panel) return;
+        panel.classList.remove('open');
+        panel.setAttribute('aria-hidden', 'true');
+        overlay.classList.remove('active');
+        if (toggle) toggle.setAttribute('aria-expanded', 'false');
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
         // Hide back button when there is nowhere to go back to
         var backBtn = document.getElementById('bottom-nav-back');
         if (backBtn && window.history.length <= 1) {
             backBtn.style.visibility = 'hidden';
         }
+
+        // Fetch unread count on load to populate badge
+        {% if user.is_authenticated %}
+        fetch(NOTIF_URL, { credentials: 'same-origin' })
+            .then(function (r) { return r.json(); })
+            .then(function (data) { setBadge(data.unread_count); })
+            .catch(function () {});
+        {% endif %}
+
+        // Bell toggle
+        var toggle = document.getElementById('notif-toggle');
+        if (toggle) {
+            toggle.addEventListener('click', function () {
+                var panel = document.getElementById('notif-panel');
+                if (panel && panel.classList.contains('open')) {
+                    closePanel();
+                } else {
+                    openPanel();
+                }
+            });
+        }
+
+        // Close button & overlay
+        var closeBtn = document.getElementById('notif-close');
+        var overlay  = document.getElementById('notif-overlay');
+        if (closeBtn) closeBtn.addEventListener('click', closePanel);
+        if (overlay)  overlay.addEventListener('click', closePanel);
 
         // Haptic + visual tap feedback on every nav control
         document.querySelectorAll('.bottom-nav-item, .bottom-nav-back').forEach(function (el) {

--- a/templates/partials/_bottom_nav.html
+++ b/templates/partials/_bottom_nav.html
@@ -21,14 +21,14 @@
 
 <nav class="bottom-nav" aria-label="Mobile navigation">
 
-    <a href="{% url 'index' %}"
-       class="bottom-nav-item{% if request.resolver_match.url_name == 'index' %} active{% endif %}"
-       aria-current="{% if request.resolver_match.url_name == 'index' %}page{% else %}false{% endif %}">
-        <i class="fas fa-home" aria-hidden="true"></i>
-        <span>Home</span>
-    </a>
-
     {% if user.is_authenticated %}
+
+        <a href="{% url 'profile' user.username %}"
+           class="bottom-nav-item{% if request.resolver_match.url_name == 'profile' %} active{% endif %}"
+           aria-current="{% if request.resolver_match.url_name == 'profile' %}page{% else %}false{% endif %}">
+            <i class="fas fa-user" aria-hidden="true"></i>
+            <span>Profile</span>
+        </a>
 
         <button class="bottom-nav-item" id="notif-toggle"
                 aria-label="Notifications" aria-expanded="false" aria-controls="notif-panel">
@@ -38,13 +38,6 @@
             </span>
             <span>Alerts</span>
         </button>
-
-        <a href="{% url 'profile' user.username %}"
-           class="bottom-nav-item{% if request.resolver_match.url_name == 'profile' %} active{% endif %}"
-           aria-current="{% if request.resolver_match.url_name == 'profile' %}page{% else %}false{% endif %}">
-            <i class="fas fa-user" aria-hidden="true"></i>
-            <span>Profile</span>
-        </a>
 
     {% else %}
 
@@ -63,6 +56,13 @@
         </a>
 
     {% endif %}
+
+    <a href="{% url 'index' %}"
+       class="bottom-nav-item{% if request.resolver_match.url_name == 'index' %} active{% endif %}"
+       aria-current="{% if request.resolver_match.url_name == 'index' %}page{% else %}false{% endif %}">
+        <i class="fas fa-home" aria-hidden="true"></i>
+        <span>Home</span>
+    </a>
 
     <div class="nav-divider" aria-hidden="true"></div>
 

--- a/templates/partials/_bottom_nav.html
+++ b/templates/partials/_bottom_nav.html
@@ -46,16 +46,6 @@
             <span>Profile</span>
         </a>
 
-        <!-- Install slot: always occupies space; shown by install-prompt.js -->
-        <button id="install-button-bottom"
-                class="bottom-nav-item install-slot"
-                title="Install Seoto as an app"
-                aria-label="Install Seoto as an app"
-                style="visibility:hidden;">
-            <i class="fas fa-download" aria-hidden="true"></i>
-            <span>Install</span>
-        </button>
-
     {% else %}
 
         <a href="{% url 'login' %}"
@@ -71,16 +61,6 @@
             <i class="fas fa-user-plus" aria-hidden="true"></i>
             <span>Sign up</span>
         </a>
-
-        <!-- Install slot: always occupies space; shown by install-prompt.js -->
-        <button id="install-button-bottom"
-                class="bottom-nav-item install-slot"
-                title="Install Seoto as an app"
-                aria-label="Install Seoto as an app"
-                style="visibility:hidden;">
-            <i class="fas fa-download" aria-hidden="true"></i>
-            <span>Install</span>
-        </button>
 
     {% endif %}
 

--- a/templates/partials/_bottom_nav.html
+++ b/templates/partials/_bottom_nav.html
@@ -1,5 +1,13 @@
 <nav class="bottom-nav" aria-label="Mobile navigation">
 
+    <button class="bottom-nav-back" id="bottom-nav-back"
+            onclick="history.back()"
+            aria-label="Go back"
+            title="Go back">
+        <i class="fas fa-chevron-left" aria-hidden="true"></i>
+        <span>Back</span>
+    </button>
+
     <a href="{% url 'index' %}"
        class="bottom-nav-item{% if request.resolver_match.url_name == 'index' %} active{% endif %}"
        aria-current="{% if request.resolver_match.url_name == 'index' %}page{% else %}false{% endif %}">
@@ -55,3 +63,27 @@
     {% endif %}
 
 </nav>
+
+<script>
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        // Hide back button when there is nowhere to go back to
+        var backBtn = document.getElementById('bottom-nav-back');
+        if (backBtn && window.history.length <= 1) {
+            backBtn.style.visibility = 'hidden';
+        }
+
+        // Haptic + visual tap feedback on every nav control
+        document.querySelectorAll('.bottom-nav-item, .bottom-nav-back').forEach(function (el) {
+            el.addEventListener('pointerdown', function () {
+                if (navigator.vibrate) navigator.vibrate(8);
+                el.classList.add('nav-tap');
+                el.addEventListener('animationend', function handler() {
+                    el.classList.remove('nav-tap');
+                    el.removeEventListener('animationend', handler);
+                });
+            });
+        });
+    });
+})();
+</script>

--- a/templates/partials/_bottom_nav.html
+++ b/templates/partials/_bottom_nav.html
@@ -76,7 +76,7 @@
         // Haptic + visual tap feedback on every nav control
         document.querySelectorAll('.bottom-nav-item, .bottom-nav-back').forEach(function (el) {
             el.addEventListener('pointerdown', function () {
-                if (navigator.vibrate) navigator.vibrate(8);
+                if (navigator.vibrate) navigator.vibrate([10, 30, 10]);
                 el.classList.add('nav-tap');
                 el.addEventListener('animationend', function handler() {
                     el.classList.remove('nav-tap');

--- a/templates/partials/_bottom_nav.html
+++ b/templates/partials/_bottom_nav.html
@@ -1,40 +1,57 @@
-<nav class="bottom-nav d-md-none" aria-label="Mobile navigation">
-    <a href="{% url 'index' %}" class="bottom-nav-item">
-        <i class="fas fa-home"></i>
+<nav class="bottom-nav" aria-label="Mobile navigation">
+
+    <a href="{% url 'index' %}"
+       class="bottom-nav-item{% if request.resolver_match.url_name == 'index' %} active{% endif %}"
+       aria-current="{% if request.resolver_match.url_name == 'index' %}page{% else %}false{% endif %}">
+        <i class="fas fa-home" aria-hidden="true"></i>
         <span>Home</span>
     </a>
 
     {% if user.is_authenticated %}
-        <a href="{% url 'profile' user.username %}" class="bottom-nav-item">
-            <i class="fas fa-user"></i>
+
+        <a href="{% url 'profile' user.username %}"
+           class="bottom-nav-item{% if request.resolver_match.url_name == 'profile' %} active{% endif %}"
+           aria-current="{% if request.resolver_match.url_name == 'profile' %}page{% else %}false{% endif %}">
+            <i class="fas fa-user" aria-hidden="true"></i>
             <span>Profile</span>
         </a>
 
-        <button id="install-button-bottom" class="bottom-nav-item" style="display:none;" title="Install Seoto as an app">
-            <i class="fas fa-download"></i>
+        <!-- Install slot: always occupies space; shown by install-prompt.js -->
+        <button id="install-button-bottom"
+                class="bottom-nav-item install-slot"
+                title="Install Seoto as an app"
+                aria-label="Install Seoto as an app"
+                style="visibility:hidden;">
+            <i class="fas fa-download" aria-hidden="true"></i>
             <span>Install</span>
         </button>
-
-        <form method="POST" action="{% url 'logout' %}" style="display:contents;">
-            {% csrf_token %}
-            <button type="submit" class="bottom-nav-item">
-                <i class="fas fa-sign-out-alt"></i>
-                <span>Logout</span>
-            </button>
-        </form>
 
     {% else %}
-        <a href="{% url 'login' %}" class="bottom-nav-item">
-            <i class="fas fa-sign-in-alt"></i>
+
+        <a href="{% url 'login' %}"
+           class="bottom-nav-item{% if request.resolver_match.url_name == 'login' %} active{% endif %}"
+           aria-current="{% if request.resolver_match.url_name == 'login' %}page{% else %}false{% endif %}">
+            <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
             <span>Login</span>
         </a>
-        <a href="{% url 'register' %}" class="bottom-nav-item">
-            <i class="fas fa-user-plus"></i>
+
+        <a href="{% url 'register' %}"
+           class="bottom-nav-item{% if request.resolver_match.url_name == 'register' %} active{% endif %}"
+           aria-current="{% if request.resolver_match.url_name == 'register' %}page{% else %}false{% endif %}">
+            <i class="fas fa-user-plus" aria-hidden="true"></i>
             <span>Sign up</span>
         </a>
-        <button id="install-button-bottom" class="bottom-nav-item" style="display:none;" title="Install Seoto as an app">
-            <i class="fas fa-download"></i>
+
+        <!-- Install slot: always occupies space; shown by install-prompt.js -->
+        <button id="install-button-bottom"
+                class="bottom-nav-item install-slot"
+                title="Install Seoto as an app"
+                aria-label="Install Seoto as an app"
+                style="visibility:hidden;">
+            <i class="fas fa-download" aria-hidden="true"></i>
             <span>Install</span>
         </button>
+
     {% endif %}
+
 </nav>


### PR DESCRIPTION
- Add active page indicator (top bar + brand colour) per nav item using
  request.resolver_match.url_name; remove Bootstrap d-md-none dependency
- Authenticated nav: Home + Profile only; Logout moved to Profile → Settings tab
- Unauthenticated nav: Home + Login + Sign up
- Install button uses visibility (not display) so its slot is always reserved,
  preventing layout shift when the PWA prompt fires
- Replace outline:none/:focus with :focus-visible + custom ring (accessibility)
- Increase label font-size 0.65rem → 0.7rem; add font-weight:500
- Visual refresh: white bg, soft box-shadow, brand-coloured active state,
  scale-on-tap feedback, -webkit-tap-highlight-color removed
- Sign-out settings row added to Profile → Settings with red icon

https://claude.ai/code/session_018uQiwz58jBvDHeikb8Rdy6

## Summary by Sourcery

Redesign the mobile bottom navigation for improved active-state highlighting, accessibility, and logout placement while preventing layout shifts from the PWA install prompt.

New Features:
- Highlight the active mobile navigation item with brand-colored styling and an indicator bar, including ARIA current page attributes.
- Reserve a persistent slot for the PWA install button in the bottom nav to avoid layout shifts when the prompt appears.
- Add a sign-out action row to the Profile settings page for authenticated users.

Bug Fixes:
- Ensure the mobile PWA install button uses visibility toggling instead of display changes to keep the layout stable when showing or hiding the prompt.

Enhancements:
- Refresh the mobile bottom nav visual design with updated colors, typography, spacing, and tap feedback, and switch to :focus-visible-based focus rings for better keyboard accessibility.
- Simplify responsive behavior by handling bottom-nav visibility via custom CSS instead of Bootstrap utility classes.