### PR TITLE
Humanize large amounts with K/M/B and keep stat rows single-line on mobile

### DIFF
--- a/spending_tracker/templatetags/spending_extras.py
+++ b/spending_tracker/templatetags/spending_extras.py
@@ -32,3 +32,29 @@ def relative_date(value):
         return 'Last week'
     else:
         return f'{value.day} {value.strftime("%b %Y")}'  # "3 Mar 2026"
+
+
+@register.filter
+def humanize_amount(value):
+    """
+    Formats a currency amount for compact display, abbreviating with K/M/B
+    once the magnitude reaches 1000 (e.g. 7800 -> "7.8K", 2300000 -> "2.3M").
+    Values under 1000 keep the standard two-decimal display (e.g. "588.00").
+    """
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return value
+
+    sign = '-' if value < 0 else ''
+    magnitude = abs(value)
+
+    if magnitude < 1000:
+        return f'{sign}{magnitude:.2f}'
+
+    for divisor, suffix in ((1_000_000_000, 'B'), (1_000_000, 'M'), (1_000, 'K')):
+        if magnitude >= divisor:
+            scaled = f'{magnitude / divisor:.2f}'.rstrip('0').rstrip('.')
+            return f'{sign}{scaled}{suffix}'
+
+    return f'{sign}{magnitude:.2f}'

--- a/spending_tracker/tests.py
+++ b/spending_tracker/tests.py
@@ -11,6 +11,7 @@ from .models import (
     RecurringFrequencyChoices, CustomRecurrenceTypeChoices, RecurringOccurrenceStatusChoices,
 )
 from .services import process_due_occurrences
+from .templatetags.spending_extras import humanize_amount
 
 
 class InfiniteScrollPartialTests(TestCase):
@@ -611,4 +612,31 @@ class EditTransactionRecurringBannerTests(TestCase):
         self.assertContains(
             response, reverse('spending_tracker:edit_recurring_transaction', args=[schedule.pk])
         )
+
+
+class HumanizeAmountFilterTests(TestCase):
+    """`humanize_amount` abbreviates large figures with K/M/B for compact display."""
+
+    def test_below_thousand_keeps_two_decimals(self):
+        self.assertEqual(humanize_amount(588), '588.00')
+        self.assertEqual(humanize_amount(0), '0.00')
+
+    def test_thousands_use_k_suffix(self):
+        self.assertEqual(humanize_amount(7800), '7.8K')
+        self.assertEqual(humanize_amount(6285.06), '6.29K')
+        self.assertEqual(humanize_amount(1000), '1K')
+
+    def test_millions_use_m_suffix(self):
+        self.assertEqual(humanize_amount(2_300_000), '2.3M')
+
+    def test_billions_use_b_suffix(self):
+        self.assertEqual(humanize_amount(4_500_000_000), '4.5B')
+
+    def test_negative_values_keep_sign(self):
+        self.assertEqual(humanize_amount(-7800), '-7.8K')
+        self.assertEqual(humanize_amount(-500), '-500.00')
+
+    def test_non_numeric_input_returned_unchanged(self):
+        self.assertEqual(humanize_amount('N/A'), 'N/A')
+        self.assertEqual(humanize_amount(None), None)
 

--- a/templates/spending_tracker/dashboard.html
+++ b/templates/spending_tracker/dashboard.html
@@ -31,6 +31,22 @@
             letter-spacing: 0.5px;
         }
 
+        @media (max-width: 576px) {
+            .stats-card {
+                padding: 10px 4px;
+                margin-bottom: 10px;
+            }
+
+            .stat-value {
+                font-size: 1rem;
+            }
+
+            .stat-label {
+                font-size: 0.55rem;
+                letter-spacing: 0;
+            }
+        }
+
         .income {
             color: #27ae60 !important;
         }
@@ -210,28 +226,28 @@
     <div class="main container">
         <!-- Financial Overview -->
         <div class="row mb-4">
-            <div class="col-md-3 col-sm-6">
+            <div class="col-3">
                 <div class="stats-card text-center">
-                    <div class="stat-value balance">{{ currency_symbol }}{{ total_balance|floatformat:2 }}</div>
+                    <div class="stat-value balance">{{ currency_symbol }}{{ total_balance|humanize_amount }}</div>
                     <div class="stat-label">Total Balance</div>
                 </div>
             </div>
-            <div class="col-md-3 col-sm-6">
+            <div class="col-3">
                 <div class="stats-card text-center">
-                    <div class="stat-value income">+{{ currency_symbol }}{{ monthly_income|floatformat:2 }}</div>
+                    <div class="stat-value income">+{{ currency_symbol }}{{ monthly_income|humanize_amount }}</div>
                     <div class="stat-label">Monthly Income</div>
                 </div>
             </div>
-            <div class="col-md-3 col-sm-6">
+            <div class="col-3">
                 <div class="stats-card text-center">
-                    <div class="stat-value expense">-{{ currency_symbol }}{{ monthly_expense|floatformat:2 }}</div>
+                    <div class="stat-value expense">-{{ currency_symbol }}{{ monthly_expense|humanize_amount }}</div>
                     <div class="stat-label">Monthly Expenses</div>
                 </div>
             </div>
-            <div class="col-md-3 col-sm-6">
+            <div class="col-3">
                 <div class="stats-card text-center">
                     <div class="stat-value {% if net_monthly >= 0 %}income{% else %}expense{% endif %}">
-                        {% if net_monthly >= 0 %}+{% endif %}{{ currency_symbol }}{{ net_monthly|floatformat:2 }}
+                        {% if net_monthly >= 0 %}+{% endif %}{{ currency_symbol }}{{ net_monthly|humanize_amount }}
                     </div>
                     <div class="stat-label">Net Monthly</div>
                 </div>

--- a/templates/spending_tracker/reports.html
+++ b/templates/spending_tracker/reports.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static spending_extras %}
 {{ trend_data|json_script:"trend-data" }}
 {{ json_expense_categories|json_script:"expense-categories-data" }}
 
@@ -154,6 +154,26 @@
             font-size: 0.9rem;
             text-transform: uppercase;
             letter-spacing: 0.5px;
+        }
+
+        @media (max-width: 576px) {
+            .metric-grid {
+                grid-template-columns: repeat(4, 1fr);
+                gap: 6px;
+            }
+
+            .metric-card {
+                padding: 8px 4px;
+            }
+
+            .metric-value {
+                font-size: 0.95rem;
+            }
+
+            .metric-label {
+                font-size: 0.55rem;
+                letter-spacing: 0;
+            }
         }
 
         .chart-empty-state {
@@ -320,18 +340,18 @@
     <!-- Top Cards -->
     <div class="metric-grid">
         <div class="metric-card" style="border-top-color: #27ae60;">
-            <div class="metric-value" style="color: #27ae60;">+{{ currency_symbol }}{{ total_income }}</div>
+            <div class="metric-value" style="color: #27ae60;">+{{ currency_symbol }}{{ total_income|humanize_amount }}</div>
             <div class="metric-label">Total Income</div>
         </div>
         <div class="metric-card" style="border-top-color: #e74c3c;">
-            <div class="metric-value" style="color: #e74c3c;">-{{ currency_symbol }}{{ total_expenses }}</div>
+            <div class="metric-value" style="color: #e74c3c;">-{{ currency_symbol }}{{ total_expenses|humanize_amount }}</div>
             <div class="metric-label">Total Expenses</div>
         </div>
         <div class="metric-card"
              style="{% if net_income >= 0 %}border-top-color: #27ae60;{% else %}border-top-color: #e74c3c;{% endif %}">
             <div class="metric-value"
                  style="{% if net_income >= 0 %}color: #27ae60;{% else %}color: #e74c3c;{% endif %}">
-                {% if net_income >= 0 %}+{% endif %}{{ currency_symbol }}{{ net_income }}
+                {% if net_income >= 0 %}+{% endif %}{{ currency_symbol }}{{ net_income|humanize_amount }}
             </div>
             <div class="metric-label">Net Income</div>
         </div>
@@ -421,7 +441,7 @@
         <div class="metric-grid">
             <div class="metric-card" style="border-top-color: #e74c3c;">
                 <div class="metric-value" style="color: #e74c3c; font-size: 1.4rem;">
-                    {{ currency_symbol }}{{ avg_daily_spending }}</div>
+                    {{ currency_symbol }}{{ avg_daily_spending|humanize_amount }}</div>
                 <div class="metric-label">Avg. Daily Spending</div>
             </div>
             <div class="metric-card" style="border-top-color: #9b59b6;">
@@ -434,7 +454,7 @@
                 </div>
                 <div class="metric-label">Top Expense Category
                     {% if top_expense_amount %}<br>
-                        <small class="text-muted">{{ currency_symbol }}{{ top_expense_amount }}</small>{% endif %}
+                        <small class="text-muted">{{ currency_symbol }}{{ top_expense_amount|humanize_amount }}</small>{% endif %}
                 </div>
             </div>
             <div class="metric-card" style="border-top-color: #3498db;">
@@ -447,7 +467,7 @@
                  style="{% if net_income >= 0 %}border-top-color: #27ae60;{% else %}border-top-color: #e74c3c;{% endif %}">
                 <div class="metric-value"
                      style="{% if net_income >= 0 %}color: #27ae60;{% else %}color: #e74c3c;{% endif %} font-size: 1.4rem;">
-                    {% if net_income >= 0 %}+{% endif %}{{ currency_symbol }}{{ net_income }}
+                    {% if net_income >= 0 %}+{% endif %}{{ currency_symbol }}{{ net_income|humanize_amount }}
                 </div>
                 <div class="metric-label">Net for Period
                     <br><small class="text-muted">{{ savings_rate }}% savings rate</small>


### PR DESCRIPTION
Adds a humanize_amount filter that abbreviates currency figures once they
hit 1000 (e.g. 7800.00 -> 7.8K, 2300000 -> 2.3M) while keeping full
precision below that. Applied it to the headline balance/income/expense
figures on the dashboard and reports pages, and adjusted their mobile
breakpoints so the four stat cards stay in one row instead of stacking.

## Summary by Sourcery

Introduce compact currency formatting and adjust dashboard/report layouts for better mobile display.

New Features:
- Add a humanize_amount template filter to abbreviate large currency values with K/M/B while preserving precision for smaller amounts.

Enhancements:
- Apply compact currency formatting to key financial metrics on the dashboard and reports pages.
- Adjust dashboard and reports metric layouts and typography so statistic cards remain single-line and readable on small screens.

Tests:
- Add unit tests covering humanize_amount behavior for various magnitudes, signs, and non-numeric inputs.