### PR TITLE
Add weather forecast widget to the app nav

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,11 @@ RECAPTCHA_SCORE_THRESHOLD=0.5
 # IPQUALITYSCORE
 IP_QUALITY_SCORE_API_KEY=
 
+# Weather widget — provider selection (see seoto/external_services/weather/factory.py).
+# Defaults are free, no API key required.
+WEATHER_PROVIDER=open_meteo
+GEOLOCATION_PROVIDER=ip_api
+
 # CALENDLY — consultation booking link
 CALENDLY_URL=https://calendly.com/anthony-asamoah/30min
 

--- a/home/tests.py
+++ b/home/tests.py
@@ -1,3 +1,85 @@
-from django.test import TestCase
+from unittest.mock import patch
 
-# Create your tests here.
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+
+
+class WeatherForecastViewTests(TestCase):
+    def setUp(self):
+        self.url = reverse('weather_forecast')
+        cache.clear()
+
+    @patch('home.views.weather.get_weather_provider')
+    def test_gps_coordinates_skip_geolocation(self, mock_get_weather_provider):
+        mock_get_weather_provider.return_value.get_forecast.return_value = {
+            'temperature': 21.0,
+            'feels_like': 20.0,
+            'humidity': 60,
+            'wind_speed': 10.0,
+            'condition_code': 1,
+            'condition_text': 'Mainly clear',
+            'icon': 'fa-sun',
+            'high': 24.0,
+            'low': 15.0,
+            'timezone': 'UTC',
+        }
+
+        response = self.client.get(self.url, {'lat': '5.6', 'lon': '-0.2'})
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['source'], 'gps')
+        self.assertEqual(data['weather']['temperature'], 21.0)
+        mock_get_weather_provider.return_value.get_forecast.assert_called_once_with(5.6, -0.2)
+
+    @patch('home.views.weather.get_weather_provider')
+    @patch('home.views.weather.get_geolocation_provider')
+    def test_defaults_to_ip_geolocation(self, mock_get_geo_provider, mock_get_weather_provider):
+        mock_get_geo_provider.return_value.locate.return_value = {
+            'lat': 5.6, 'lon': -0.2, 'city': 'Accra', 'region': 'Greater Accra', 'country': 'Ghana',
+        }
+        mock_get_weather_provider.return_value.get_forecast.return_value = {
+            'temperature': 27.0, 'feels_like': 29.0, 'humidity': 70, 'wind_speed': 8.0,
+            'condition_code': 2, 'condition_text': 'Partly cloudy', 'icon': 'fa-cloud-sun',
+            'high': 30.0, 'low': 22.0, 'timezone': 'Africa/Accra',
+        }
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['source'], 'ip')
+        self.assertEqual(data['location']['city'], 'Accra')
+        mock_get_geo_provider.return_value.locate.assert_called_once()
+
+    @patch('home.views.weather.get_geolocation_provider')
+    def test_returns_503_when_ip_cannot_be_located(self, mock_get_geo_provider):
+        mock_get_geo_provider.return_value.locate.return_value = None
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 503)
+        self.assertIn('error', response.json())
+
+    @patch('home.views.weather.get_weather_provider')
+    @patch('home.views.weather.get_geolocation_provider')
+    def test_returns_503_when_weather_provider_fails(self, mock_get_geo_provider, mock_get_weather_provider):
+        mock_get_geo_provider.return_value.locate.return_value = {
+            'lat': 5.6, 'lon': -0.2, 'city': 'Accra', 'region': 'Greater Accra', 'country': 'Ghana',
+        }
+        mock_get_weather_provider.return_value.get_forecast.return_value = None
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 503)
+
+    def test_invalid_coordinates_return_400(self):
+        response = self.client.get(self.url, {'lat': 'not-a-number', 'lon': '-0.2'})
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_rejects_non_get_methods(self):
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, 405)

--- a/home/urls.py
+++ b/home/urls.py
@@ -9,6 +9,7 @@ from home.views import (
     message_detail,
     messages_list,
     user_analytics,
+    weather_forecast,
 )
 
 urlpatterns = [
@@ -19,4 +20,5 @@ urlpatterns = [
     path('dashboard/messages/', messages_list, name='dashboard_messages'),
     path('dashboard/messages/<int:pk>/', message_detail, name='message_detail'),
     path('incoming', incoming, name='incoming'),
+    path('weather/forecast/', weather_forecast, name='weather_forecast'),
 ]

--- a/home/views/__init__.py
+++ b/home/views/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "app_usage",
     "messages_list",
     "message_detail",
+    "weather_forecast",
 ]
 
 from home.views.dash import dashboard
@@ -23,3 +24,4 @@ from home.views.monitoring import (
     messages_list,
     user_analytics,
 )
+from home.views.weather import weather_forecast

--- a/home/views/weather.py
+++ b/home/views/weather.py
@@ -1,0 +1,67 @@
+import logging
+
+from django.core.cache import cache
+from django.http import JsonResponse
+from django.views.decorators.http import require_http_methods
+
+from home.utils import get_client_ip
+from seoto.external_services.weather import get_geolocation_provider, get_weather_provider
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS = 600
+
+
+@require_http_methods(["GET"])
+def weather_forecast(request):
+    """
+    Return current weather for the requester.
+
+    Defaults to IP-based geolocation; pass ?lat=&lon= (from the browser's
+    Geolocation API) to use a precise GPS fix instead.
+    """
+    lat = request.GET.get('lat')
+    lon = request.GET.get('lon')
+
+    try:
+        if lat and lon:
+            lat, lon = float(lat), float(lon)
+            location = {'city': '', 'region': '', 'country': ''}
+            source = 'gps'
+        else:
+            ip = get_client_ip(request)
+            cache_key = f'weather:geo:{ip}'
+            location = cache.get(cache_key)
+            if location is None:
+                location = get_geolocation_provider().locate(ip)
+                if location is not None:
+                    cache.set(cache_key, location, CACHE_TTL_SECONDS)
+
+            if location is None:
+                return JsonResponse(
+                    {'error': 'Could not determine your location from your IP address.'},
+                    status=503,
+                )
+            lat, lon = location['lat'], location['lon']
+            source = 'ip'
+
+        weather_cache_key = f'weather:forecast:{round(lat, 2)}:{round(lon, 2)}'
+        weather = cache.get(weather_cache_key)
+        if weather is None:
+            weather = get_weather_provider().get_forecast(lat, lon)
+            if weather is not None:
+                cache.set(weather_cache_key, weather, CACHE_TTL_SECONDS)
+
+        if weather is None:
+            return JsonResponse({'error': 'Weather service is currently unavailable.'}, status=503)
+
+        return JsonResponse({
+            'source': source,
+            'location': location,
+            'weather': weather,
+        })
+    except (TypeError, ValueError):
+        return JsonResponse({'error': 'Invalid coordinates.'}, status=400)
+    except Exception:
+        logger.exception('weather_forecast failed')
+        return JsonResponse({'error': 'Could not load weather.'}, status=500)

--- a/seoto/external_services/weather/__init__.py
+++ b/seoto/external_services/weather/__init__.py
@@ -1,0 +1,3 @@
+from .factory import get_geolocation_provider, get_weather_provider
+
+__all__ = ['get_weather_provider', 'get_geolocation_provider']

--- a/seoto/external_services/weather/base.py
+++ b/seoto/external_services/weather/base.py
@@ -1,0 +1,29 @@
+"""
+Provider interfaces for the weather widget.
+
+Concrete implementations live in `providers.py`; `factory.py` picks one at
+runtime from settings.WEATHER_PROVIDER / settings.GEOLOCATION_PROVIDER, so a
+provider can be swapped out without touching any call site.
+"""
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class WeatherProvider(ABC):
+    @abstractmethod
+    def get_forecast(self, lat: float, lon: float) -> Optional[dict]:
+        """
+        Return a normalized forecast dict:
+            {temperature, feels_like, humidity, wind_speed,
+             condition_code, condition_text, icon, high, low, timezone}
+        or None if the forecast could not be retrieved.
+        """
+
+
+class GeolocationProvider(ABC):
+    @abstractmethod
+    def locate(self, ip: str) -> Optional[dict]:
+        """
+        Return a normalized dict: {lat, lon, city, region, country}
+        or None if the IP could not be located.
+        """

--- a/seoto/external_services/weather/factory.py
+++ b/seoto/external_services/weather/factory.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+
+from .providers import IpApiGeolocationProvider, OpenMeteoWeatherProvider
+
+WEATHER_PROVIDERS = {
+    'open_meteo': OpenMeteoWeatherProvider,
+}
+
+GEOLOCATION_PROVIDERS = {
+    'ip_api': IpApiGeolocationProvider,
+}
+
+
+def get_weather_provider():
+    provider_cls = WEATHER_PROVIDERS[settings.WEATHER_PROVIDER]
+    return provider_cls()
+
+
+def get_geolocation_provider():
+    provider_cls = GEOLOCATION_PROVIDERS[settings.GEOLOCATION_PROVIDER]
+    return provider_cls()

--- a/seoto/external_services/weather/providers.py
+++ b/seoto/external_services/weather/providers.py
@@ -1,0 +1,116 @@
+import logging
+
+import httpx
+
+from .base import GeolocationProvider, WeatherProvider
+
+logger = logging.getLogger(__name__)
+
+# Suppress httpx debug logging so request URLs don't leak into logs.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+# WMO weather codes (used by Open-Meteo) -> (human text, Font Awesome icon class)
+_WMO_CONDITIONS = {
+    0: ('Clear sky', 'fa-sun'),
+    1: ('Mainly clear', 'fa-sun'),
+    2: ('Partly cloudy', 'fa-cloud-sun'),
+    3: ('Overcast', 'fa-cloud'),
+    45: ('Fog', 'fa-smog'),
+    48: ('Depositing rime fog', 'fa-smog'),
+    51: ('Light drizzle', 'fa-cloud-rain'),
+    53: ('Drizzle', 'fa-cloud-rain'),
+    55: ('Dense drizzle', 'fa-cloud-rain'),
+    56: ('Freezing drizzle', 'fa-cloud-rain'),
+    57: ('Freezing drizzle', 'fa-cloud-rain'),
+    61: ('Slight rain', 'fa-cloud-rain'),
+    63: ('Rain', 'fa-cloud-showers-heavy'),
+    65: ('Heavy rain', 'fa-cloud-showers-heavy'),
+    66: ('Freezing rain', 'fa-cloud-showers-heavy'),
+    67: ('Freezing rain', 'fa-cloud-showers-heavy'),
+    71: ('Slight snow', 'fa-snowflake'),
+    73: ('Snow', 'fa-snowflake'),
+    75: ('Heavy snow', 'fa-snowflake'),
+    77: ('Snow grains', 'fa-snowflake'),
+    80: ('Slight showers', 'fa-cloud-rain'),
+    81: ('Showers', 'fa-cloud-showers-heavy'),
+    82: ('Violent showers', 'fa-cloud-showers-heavy'),
+    85: ('Slight snow showers', 'fa-snowflake'),
+    86: ('Heavy snow showers', 'fa-snowflake'),
+    95: ('Thunderstorm', 'fa-bolt'),
+    96: ('Thunderstorm with hail', 'fa-bolt'),
+    99: ('Thunderstorm with heavy hail', 'fa-bolt'),
+}
+_DEFAULT_CONDITION = ('Unknown', 'fa-cloud')
+
+
+class OpenMeteoWeatherProvider(WeatherProvider):
+    """https://open-meteo.com — free, no API key required."""
+
+    BASE_URL = 'https://api.open-meteo.com/v1/forecast'
+
+    def get_forecast(self, lat, lon):
+        try:
+            response = httpx.get(
+                self.BASE_URL,
+                params={
+                    'latitude': lat,
+                    'longitude': lon,
+                    'current': 'temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m',
+                    'daily': 'temperature_2m_max,temperature_2m_min',
+                    'timezone': 'auto',
+                },
+                timeout=8,
+            )
+            response.raise_for_status()
+            data = response.json()
+            current = data['current']
+            daily = data['daily']
+            code = current.get('weather_code')
+            text, icon = _WMO_CONDITIONS.get(code, _DEFAULT_CONDITION)
+
+            return {
+                'temperature': current.get('temperature_2m'),
+                'feels_like': current.get('apparent_temperature'),
+                'humidity': current.get('relative_humidity_2m'),
+                'wind_speed': current.get('wind_speed_10m'),
+                'condition_code': code,
+                'condition_text': text,
+                'icon': icon,
+                'high': (daily.get('temperature_2m_max') or [None])[0],
+                'low': (daily.get('temperature_2m_min') or [None])[0],
+                'timezone': data.get('timezone'),
+            }
+        except Exception:
+            logger.exception('OpenMeteoWeatherProvider.get_forecast failed for (%s, %s)', lat, lon)
+            return None
+
+
+class IpApiGeolocationProvider(GeolocationProvider):
+    """https://ip-api.com — free, no API key required (HTTP only on the free tier)."""
+
+    BASE_URL = 'http://ip-api.com/json/{ip}'
+
+    def locate(self, ip):
+        try:
+            response = httpx.get(
+                self.BASE_URL.format(ip=ip),
+                params={'fields': 'status,message,lat,lon,city,regionName,country'},
+                timeout=8,
+            )
+            response.raise_for_status()
+            data = response.json()
+            if data.get('status') != 'success':
+                logger.info('IpApiGeolocationProvider could not locate IP %s: %s', ip, data.get('message'))
+                return None
+
+            return {
+                'lat': data['lat'],
+                'lon': data['lon'],
+                'city': data.get('city', ''),
+                'region': data.get('regionName', ''),
+                'country': data.get('country', ''),
+            }
+        except Exception:
+            logger.exception('IpApiGeolocationProvider.locate failed for IP %s', ip)
+            return None

--- a/seoto/settings.py
+++ b/seoto/settings.py
@@ -314,6 +314,12 @@ RECAPTCHA_ENABLED = all([RECAPTCHA_SITE_KEY, RECAPTCHA_SECRET_KEY, RECAPTCHA_VER
 # IP Quality Score API Key
 IP_QUALITY_SCORE_API_KEY = config('IP_QUALITY_SCORE_API_KEY', default="None")
 
+# Weather widget — provider name selects an implementation via the factory in
+# seoto/external_services/weather/factory.py, so providers can be swapped
+# without touching call sites. Both defaults are free and require no API key.
+WEATHER_PROVIDER = config('WEATHER_PROVIDER', default='open_meteo')
+GEOLOCATION_PROVIDER = config('GEOLOCATION_PROVIDER', default='ip_api')
+
 # Calendly — consultation booking link shown on the reach-out page after the
 # qualifying form is submitted. Swap the default for your real scheduling URL.
 CALENDLY_URL = config('CALENDLY_URL', default='https://calendly.com/anthony-asamoah/30min')

--- a/templates/base.html
+++ b/templates/base.html
@@ -554,6 +554,79 @@
             font-size: 1.6rem;
         }
 
+        /* Weather widget */
+        .weather-body {
+            padding: 18px 16px 20px;
+            overflow-y: auto;
+            flex: 1;
+        }
+
+        .weather-current {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+            margin-bottom: 4px;
+        }
+
+        .weather-current i {
+            font-size: 2.2rem;
+            color: #175a9c;
+        }
+
+        .weather-temp {
+            font-size: 2.2rem;
+            font-weight: 700;
+            color: #111827;
+        }
+
+        .weather-place {
+            text-align: center;
+            font-size: 0.9rem;
+            font-weight: 600;
+            color: #111827;
+        }
+
+        .weather-condition {
+            text-align: center;
+            font-size: 0.8rem;
+            color: #6b7280;
+            margin-bottom: 14px;
+        }
+
+        .weather-details {
+            display: flex;
+            justify-content: space-around;
+            gap: 8px;
+            font-size: 0.75rem;
+            color: #6b7280;
+            border-top: 1px solid #f3f4f6;
+            border-bottom: 1px solid #f3f4f6;
+            padding: 10px 0;
+            margin-bottom: 10px;
+        }
+
+        .weather-details i {
+            margin-right: 4px;
+            color: #175a9c;
+        }
+
+        .weather-hilo {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #111827;
+            margin-bottom: 8px;
+        }
+
+        .weather-source {
+            text-align: center;
+            font-size: 0.68rem;
+            color: #9ca3af;
+        }
+
         /* Mobile: show bottom nav, hide top navbar, pad page content */
         @media (max-width: 768px) {
             .bottom-nav {

--- a/templates/partials/_bottom_nav.html
+++ b/templates/partials/_bottom_nav.html
@@ -1,5 +1,28 @@
 {% url 'pwa:notifications_list' as notif_url %}
 {% url 'pwa:mark_notifications_read' as notif_read_url %}
+{% url 'weather_forecast' as weather_url %}
+
+<!-- Weather dropdown panel (available to all visitors, authenticated or not) -->
+<div id="weather-overlay" class="notif-overlay" aria-hidden="true"></div>
+<div id="weather-panel" class="notif-panel" role="dialog" aria-label="Weather" aria-hidden="true">
+    <div class="notif-panel-header">
+        <span class="notif-panel-title">Weather</span>
+        <div class="notif-panel-actions">
+            <button type="button" class="notif-push-toggle" id="weather-locate-btn">
+                <i class="fas fa-location-crosshairs" aria-hidden="true"></i>
+                <span>Use my location</span>
+            </button>
+            <button class="notif-panel-close" id="weather-close" aria-label="Close weather">
+                <i class="fas fa-times" aria-hidden="true"></i>
+            </button>
+        </div>
+    </div>
+    <div class="weather-body" id="weather-body">
+        <div class="notif-loading">
+            <i class="fas fa-spinner fa-spin"></i>
+        </div>
+    </div>
+</div>
 
 <!-- Notification dropdown panel (slides up from above the nav) -->
 {% if user.is_authenticated %}
@@ -69,6 +92,12 @@
         <i class="fas fa-home" aria-hidden="true"></i>
         <span>Home</span>
     </a>
+
+    <button class="bottom-nav-item" id="weather-toggle-mobile"
+            aria-label="Weather" aria-expanded="false" aria-controls="weather-panel">
+        <i class="fas fa-cloud-sun" aria-hidden="true"></i>
+        <span>Weather</span>
+    </button>
 
     <div class="nav-divider" aria-hidden="true"></div>
 
@@ -141,6 +170,8 @@
         var overlay = document.getElementById('notif-overlay');
         if (!panel) return;
 
+        if (window.SeotoCloseWeatherPanel) window.SeotoCloseWeatherPanel();
+
         panel.classList.add('open');
         panel.setAttribute('aria-hidden', 'false');
         overlay.classList.add('active');
@@ -190,6 +221,8 @@
         });
     }
 
+    window.SeotoCloseNotifPanel = closePanel;
+
     document.addEventListener('DOMContentLoaded', function () {
         // Hide back button when there is nowhere to go back to
         var backBtn = document.getElementById('bottom-nav-back');
@@ -237,6 +270,145 @@
                 });
             });
         });
+    });
+})();
+</script>
+
+<script>
+(function () {
+    var FORECAST_URL = '{{ weather_url }}';
+    var lastPayload = null; // avoid refetching every time the panel is reopened
+
+    function formatTemp(value) {
+        if (value === null || value === undefined) return '--';
+        return Math.round(value) + '°C';
+    }
+
+    function renderWeather(payload) {
+        var body = document.getElementById('weather-body');
+        if (!body) return;
+        var w = payload.weather;
+        var loc = payload.location || {};
+        var placeName = payload.source === 'gps'
+            ? 'Your current location'
+            : ([loc.city, loc.region, loc.country].filter(Boolean).join(', ') || 'Your area');
+
+        body.innerHTML =
+            '<div class="weather-current">' +
+                '<i class="fas ' + w.icon + '" aria-hidden="true"></i>' +
+                '<div class="weather-temp">' + formatTemp(w.temperature) + '</div>' +
+            '</div>' +
+            '<div class="weather-place">' + placeName + '</div>' +
+            '<div class="weather-condition">' + w.condition_text + '</div>' +
+            '<div class="weather-details">' +
+                '<span><i class="fas fa-temperature-low" aria-hidden="true"></i> Feels ' + formatTemp(w.feels_like) + '</span>' +
+                '<span><i class="fas fa-tint" aria-hidden="true"></i> ' + (w.humidity != null ? w.humidity + '%' : '--') + '</span>' +
+                '<span><i class="fas fa-wind" aria-hidden="true"></i> ' + (w.wind_speed != null ? Math.round(w.wind_speed) + 'km/h' : '--') + '</span>' +
+            '</div>' +
+            '<div class="weather-hilo"><span>H: ' + formatTemp(w.high) + '</span><span>L: ' + formatTemp(w.low) + '</span></div>' +
+            '<div class="weather-source">' + (payload.source === 'gps' ? 'Based on your device location' : 'Based on your approximate (IP) location') + '</div>';
+    }
+
+    function renderError(message) {
+        var body = document.getElementById('weather-body');
+        if (!body) return;
+        body.innerHTML = '<div class="notif-empty"><i class="fas fa-exclamation-circle"></i><span>' + message + '</span></div>';
+    }
+
+    function fetchWeather(query) {
+        var body = document.getElementById('weather-body');
+        if (body) body.innerHTML = '<div class="notif-loading"><i class="fas fa-spinner fa-spin"></i></div>';
+
+        fetch(FORECAST_URL + (query ? '?' + query : ''), { credentials: 'same-origin' })
+            .then(function (r) {
+                if (!r.ok) throw new Error('HTTP ' + r.status);
+                return r.json();
+            })
+            .then(function (data) {
+                lastPayload = data;
+                renderWeather(data);
+            })
+            .catch(function (err) {
+                console.error('[Seoto] Weather fetch failed:', err && err.message);
+                renderError('Could not load weather right now.');
+            });
+    }
+
+    function useMyLocation() {
+        if (!navigator.geolocation) {
+            renderError('Precise location is not supported on this browser.');
+            return;
+        }
+        var body = document.getElementById('weather-body');
+        if (body) body.innerHTML = '<div class="notif-loading"><i class="fas fa-spinner fa-spin"></i></div>';
+
+        navigator.geolocation.getCurrentPosition(
+            function (position) {
+                fetchWeather('lat=' + position.coords.latitude + '&lon=' + position.coords.longitude);
+            },
+            function () {
+                renderError('Location permission denied — showing your approximate location instead.');
+                if (lastPayload) renderWeather(lastPayload);
+            },
+            { timeout: 10000, maximumAge: 300000 }
+        );
+    }
+
+    function openWeatherPanel() {
+        var panel   = document.getElementById('weather-panel');
+        var overlay = document.getElementById('weather-overlay');
+        if (!panel) return;
+
+        if (window.SeotoCloseNotifPanel) window.SeotoCloseNotifPanel();
+
+        panel.classList.add('open');
+        panel.setAttribute('aria-hidden', 'false');
+        overlay.classList.add('active');
+        ['weather-toggle', 'weather-toggle-mobile'].forEach(function (id) {
+            var el = document.getElementById(id);
+            if (el) el.setAttribute('aria-expanded', 'true');
+        });
+
+        if (!lastPayload) fetchWeather();
+    }
+
+    function closeWeatherPanel() {
+        var panel   = document.getElementById('weather-panel');
+        var overlay = document.getElementById('weather-overlay');
+        if (!panel) return;
+        panel.classList.remove('open');
+        panel.setAttribute('aria-hidden', 'true');
+        overlay.classList.remove('active');
+        ['weather-toggle', 'weather-toggle-mobile'].forEach(function (id) {
+            var el = document.getElementById(id);
+            if (el) el.setAttribute('aria-expanded', 'false');
+        });
+    }
+
+    window.SeotoCloseWeatherPanel = closeWeatherPanel;
+
+    document.addEventListener('DOMContentLoaded', function () {
+        ['weather-toggle', 'weather-toggle-mobile'].forEach(function (id) {
+            var toggle = document.getElementById(id);
+            if (toggle) {
+                toggle.addEventListener('click', function () {
+                    var panel = document.getElementById('weather-panel');
+                    if (panel && panel.classList.contains('open')) {
+                        closeWeatherPanel();
+                    } else {
+                        openWeatherPanel();
+                    }
+                });
+            }
+        });
+
+        var closeBtn = document.getElementById('weather-close');
+        var overlay  = document.getElementById('weather-overlay');
+        if (closeBtn) closeBtn.addEventListener('click', closeWeatherPanel);
+        if (overlay)  overlay.addEventListener('click', closeWeatherPanel);
+
+        var locateBtn = document.getElementById('weather-locate-btn');
+        if (locateBtn) locateBtn.addEventListener('click', useMyLocation);
     });
 })();
 </script>

--- a/templates/partials/_nav.html
+++ b/templates/partials/_nav.html
@@ -41,6 +41,10 @@
             <button id="install-button" class="nav-icon-btn" style="display: none;" title="Install Seoto as an app">
                 <i class="fas fa-download"></i>
             </button>
+            <!-- Weather Toggle Button -->
+            <button id="weather-toggle" class="nav-icon-btn" title="Weather" aria-expanded="false" aria-controls="weather-panel">
+                <i class="fas fa-cloud-sun"></i>
+            </button>
             <!-- Notification Toggle Button (for authenticated users) -->
             {% if user.is_authenticated %}
             <button id="notification-toggle" class="nav-icon-btn position-relative" title="Notifications" aria-expanded="false" aria-controls="notif-panel">


### PR DESCRIPTION
Icon sits in the top navbar (desktop) and bottom nav (mobile), opening a
dropdown/bottom-sheet panel matching the existing notification widget's
UX. Defaults to IP-based geolocation and offers a "Use my location"
button for a precise GPS fix via the browser Geolocation API.

Weather and geolocation providers are selected through a factory
(seoto/external_services/weather/factory.py) so they can be swapped via
settings without touching call sites. Ships with free, keyless defaults
(Open-Meteo + ip-api.com).

## Summary by Sourcery

Add a configurable weather forecast widget to the navigation that surfaces current conditions based on IP or optional GPS coordinates and exposes them via a new backend endpoint and widget UI.

New Features:
- Introduce a weather forecast API endpoint that returns normalized current conditions for the requester using either IP-based geolocation or explicit GPS coordinates.
- Add a weather widget UI in the top and bottom navigation that opens a panel showing current conditions, location context, and basic metrics with an optional "Use my location" action.
- Provide pluggable weather and geolocation providers wired through a factory with default Open-Meteo and ip-api implementations, configurable via settings.

Enhancements:
- Integrate weather and notification panels so opening one closes the other, sharing overlay behavior for a consistent UX.

Tests:
- Add unit tests for the weather forecast endpoint covering GPS overrides, IP-based defaults, invalid input, provider failures, and HTTP method restrictions.

Chores:
- Add environment configuration defaults for selecting weather and geolocation providers and document them in the example env file.