### PR TITLE
Fix stat card value wrapping on mobile single-row layout

### DIFF
--- a/templates/spending_tracker/dashboard.html
+++ b/templates/spending_tracker/dashboard.html
@@ -22,6 +22,7 @@
             font-size: 1.8rem;
             font-weight: bold;
             color: #2c3e50;
+            white-space: nowrap;
         }
 
         .stat-label {
@@ -38,7 +39,7 @@
             }
 
             .stat-value {
-                font-size: 1rem;
+                font-size: 0.85rem;
             }
 
             .stat-label {
@@ -225,7 +226,7 @@
 
     <div class="main container">
         <!-- Financial Overview -->
-        <div class="row mb-4">
+        <div class="row mb-4 g-1">
             <div class="col-3">
                 <div class="stats-card text-center">
                     <div class="stat-value balance">{{ currency_symbol }}{{ total_balance|humanize_amount }}</div>

--- a/templates/spending_tracker/reports.html
+++ b/templates/spending_tracker/reports.html
@@ -147,6 +147,7 @@
             font-size: 1.8rem;
             font-weight: bold;
             margin-bottom: 5px;
+            white-space: nowrap;
         }
 
         .metric-label {
@@ -167,7 +168,7 @@
             }
 
             .metric-value {
-                font-size: 0.95rem;
+                font-size: 0.85rem !important;
             }
 
             .metric-label {


### PR DESCRIPTION
## Summary
- The Spending Tracker home and reports pages' headline currency cards (Monthly Expenses, Net Monthly, Net for Period, etc.) now keep the leading `+`/`-` sign glued to the number on mobile. Previously the sign could wrap onto its own line (e.g. `-` then `₵588.00` on the next line) once the four-card row was narrowed to fit a single row on small screens.
- Added `white-space: nowrap` to `.stat-value` (dashboard) and `.metric-value` (reports), since a `+`/`-` immediately before a number is a valid line-break point in the browser's default line-breaking rules.
- The reports page's "Summary Insights" cards hardcode a larger inline `font-size: 1.4rem`, which was bypassing the mobile font-size shrink used elsewhere in the grid. Added an `!important` mobile override so those cards shrink in step with the rest of the grid and fit within the single-row layout.

This follows up on the already-merged humanize (K/M/B abbreviation) and single-row layout change from PR #91.

## Test plan
- [x] `python manage.py test spending_tracker` — all 49 tests pass
- [x] Verified visually with a local Bootstrap-backed render at a 390px mobile viewport (Playwright): all four dashboard cards and all reports metric cards stay on a single line with no mid-value wrapping, including the previously-broken `-₵588.00` and `+₵7.21K` cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XwMqAdxfvr9tz367mNM2Ca)_

## Summary by Sourcery

Ensure spending tracker stat and metric cards render cleanly in a single row on small screens without breaking numeric values across lines.

Enhancements:
- Prevent dashboard and reports currency values from wrapping between the sign and the number by making stat and metric values non-wrapping.
- Adjust mobile font sizes for dashboard and reports metric values so all headline cards fit within the single-row mobile layout.
- Tighten spacing in the dashboard overview row to better accommodate four cards on narrow viewports.